### PR TITLE
Add: issue #100 comments explaining tests + one new test

### DIFF
--- a/assignment1_DECIDE/src/tests/TestDecide.java
+++ b/assignment1_DECIDE/src/tests/TestDecide.java
@@ -12,7 +12,10 @@ import src.Operator;
 
 public class TestDecide{
 
-
+/*
+ * Tests that Decide returns true when no LIC is need to be checked 
+ * (PUV[i] is false for all i)
+ */
   @Test
   public void testDecideTrue0() {
     Point[] points = {
@@ -85,6 +88,10 @@ public class TestDecide{
     Assert.assertTrue(res);
   }
 
+  /*
+   * Tests that operators (CONNECTORS) behave as they should when only PUV[0] is true and
+   * only LIC0, LIC1, LIC2, LIC5 are satisfied
+   */
   @Test
   public void testDecideTrue1() {
     Point[] points = {
@@ -157,6 +164,11 @@ public class TestDecide{
     Assert.assertTrue(res);
   }
 
+  /*
+  * Tests that when more than one PUV[i] is true and LCM is 
+  * setup successfully decide returns true
+  * LIC0, LIC1, LIC5, LIC7, LIC8, LIC11 are satisfied
+  */
   @Test
   public void testDecideTrue2() {
     Point[] points = {
@@ -212,6 +224,10 @@ public class TestDecide{
     Assert.assertTrue(res);
   }
 
+  /*
+   * Tests that when all LIC's are satisfied, all PUV's are set to true 
+   * and lcm is all ANDD decide returns true.
+   */
   @Test
   public void testDecideTrue3() {
     Point[] points = {
@@ -264,7 +280,11 @@ public class TestDecide{
     boolean res = li.decide();
     Assert.assertTrue(res);
   }
-
+  
+  /*
+  * Tests that when none of the LIC's are satisfied, PUV is all true, 
+  * and LCM is all ORR decide returns false
+  */
   @Test
   public void testDecideFalse0() {
     Point[] points = {
@@ -369,6 +389,66 @@ public class TestDecide{
     };
 
     boolean[] puv = {true,false,true,false,true,true,true,true,true,true,true,true,true,true,true};
+    LaunchInterceptor li = new LaunchInterceptor(points.length, points, params, lcm, puv);
+    boolean res = li.decide();
+    Assert.assertFalse(res);
+  }
+
+  /*
+  * Tests that when LCM is setup with an ANDD between one satisfied LIC and one 
+  * unsafisfied LIC it returns false. Everything else is satisfied.
+  * LIC0 is satisfied, LIC2 is not. The ANDD operation between them should return false
+  */
+  @Test
+  public void testDecideFalse2() {
+    Point[] points = {
+      new Point(6.0,0),
+      new Point(5,1),
+      new Point(4,2),
+      new Point(3,3),
+      new Point(2,4),
+      new Point(1,5),
+      new Point(0,6),
+    };
+    LaunchParameters params = new LaunchParameters();
+    params.LENGTH1 = 1;
+    params.RADIUS1 = 1;
+    params.EPSILON = 1;
+    params.AREA1 = 1;
+    params.Q_PTS = 1;
+    params.QUADS = 1;
+    params.DIST = 1;
+    params.N_PTS = 1;
+    params.K_PTS = 1;
+    params.A_PTS = 1;
+    params.B_PTS = 1;
+    params.C_PTS = 1;
+    params.D_PTS = 1;
+    params.E_PTS = 1;
+    params.F_PTS = 1;
+    params.G_PTS = 1;
+    params.LENGTH2 = 1;
+    params.RADIUS2 = 1;
+    params.AREA2 = 1;
+    Operator[][] lcm = {
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ORR,Operator.ORR,Operator.ANDD,Operator.ORR,Operator.ANDD,Operator.ANDD,Operator.ORR,Operator.ORR,Operator.ANDD,Operator.ORR,Operator.ORR,Operator.NOTUSED}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ORR, Operator.ORR,Operator.ORR,Operator.ANDD,Operator.ORR,Operator.ANDD,Operator.ANDD,Operator.ORR,Operator.ORR,Operator.ANDD,Operator.ORR,Operator.ORR,Operator.ORR}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+      {Operator.ANDD, Operator.ANDD, Operator.ANDD, Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD,Operator.ANDD}, 
+    };
+
+    boolean[] puv = {true,true,false,false,false,false,false,false,false,false,false,false,false,false,false};
     LaunchInterceptor li = new LaunchInterceptor(points.length, points, params, lcm, puv);
     boolean res = li.decide();
     Assert.assertFalse(res);


### PR DESCRIPTION
Added comments for decide tests.
As well as one "rainy day" test checking that an ANDD between one satisfied LIC and one unsatisfied LIC leads to false. 

Issue #100 