### PR TITLE
Add: issue #111 Implementation of clone

### DIFF
--- a/assignment2/Cargo.toml
+++ b/assignment2/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+git2 = "0.18.1"

--- a/assignment2/src/repository.rs
+++ b/assignment2/src/repository.rs
@@ -1,15 +1,28 @@
-pub struct Repository {
+use git2::Repository;
+
+pub struct Repo {
     url: String,
     path: String, // Path to local repo
     branch: String,
     commit_id: String,
 }
 
-impl Repository {
-    pub fn new() -> Self {
-        todo!("Implement this function")
+impl Repo {
+    pub fn new(url: String, path: String, branch: String, commit_id: String) -> Self {
+        Self {
+            url,
+            path,
+            branch,
+            commit_id,
+        }
     }
-    pub fn clone(&self) {}
+    pub fn clone(&self) {
+        println!("Cloning repo from {} to {}", self.url, self.path);
+        let repo = match Repository::clone(&self.url, &self.path) {
+            Ok(repo) => repo,
+            Err(e) => panic!("failed to clone: {}", e),
+        };
+    }
     pub fn checkout(&self) {}
     pub fn cleanup(&self) {}
 }

--- a/assignment2/src/repository.rs
+++ b/assignment2/src/repository.rs
@@ -7,7 +7,20 @@ pub struct Repo {
     commit_id: String,
 }
 
+/// Represents a repository.
 impl Repo {
+    /// Creates a new instance of `Repo`.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the repository.
+    /// * `path` - The local path where the repository will be cloned.
+    /// * `branch` - The branch to be checked out.
+    /// * `commit_id` - The commit ID to be checked out.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `Repo`.
     pub fn new(url: String, path: String, branch: String, commit_id: String) -> Self {
         Self {
             url,
@@ -16,6 +29,9 @@ impl Repo {
             commit_id,
         }
     }
+
+    /// Clones the repository from the URL specified in `self.url`
+    /// to the path specified in `self.path`.
     pub fn clone(&self) {
         println!("Cloning repo from {} to {}", self.url, self.path);
         let repo = match Repository::clone(&self.url, &self.path) {
@@ -23,8 +39,16 @@ impl Repo {
             Err(e) => panic!("failed to clone: {}", e),
         };
     }
-    pub fn checkout(&self) {}
-    pub fn cleanup(&self) {}
+
+    /// Checks out a specific branch or commit.
+    pub fn checkout(&self) {
+        // TODO: Implement checkout logic
+    }
+
+    /// Cleans up the repository.
+    pub fn cleanup(&self) {
+        // TODO: Implement cleanup logic
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implementation of clone.
It would be nice in the future if we could reuse the git2::Repository in checkout after cloning. I thought of adding the git2::Repository as a field to the Repo struct but that leads to a lot of Some().

Will add tests once cleanup() is implemented

Any input appreciated.

Closes #111