### PR TITLE
Add: issue #121 github webhook parsing and tests

### DIFF
--- a/assignment2/Cargo.lock
+++ b/assignment2/Cargo.lock
@@ -5,3 +5,85 @@ version = 3
 [[package]]
 name = "assignment2"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "serde"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/assignment2/Cargo.toml
+++ b/assignment2/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.113"

--- a/assignment2/src/github.rs
+++ b/assignment2/src/github.rs
@@ -1,14 +1,98 @@
-use crate::ci::Status;
+//! A module for handling everything related to GitHub.
 
+use serde::Deserialize;
+
+// use crate::ci::Status;
+
+#[derive(Deserialize)]
 struct WebhookData {
-    repo: String,
+    r#ref: String, // have to use r#ref because ref is a reserved keyword
+    after: String,
+    repository: Repository,
 }
 
+#[derive(Deserialize)]
+struct Repository {
+    ssh_url: String,
+    clone_url: String,
+}
+
+/// A struct that contains the data from a Github webhook.
+/// This relates to actions involving GitHub, e.g. sending a commit status.
 pub struct Github {
-    webhook_data: Option<WebhookData>,
+    webhook_data: WebhookData,
 }
 
 impl Github {
-    pub fn parse_webhook(&mut self, data: String) {}
-    pub fn send_commit_status(&self, status: &Status) {}
+    /// Create a new Github object from the webhook data.
+    ///
+    /// If the webhook data is not valid JSON or have the correct structure, an error is returned.
+    pub fn new(data: &str) -> Result<Github, String> {
+        let webhook_data: WebhookData = match serde_json::from_str(data) {
+            Ok(data) => data,
+            Err(e) => return Err(e.to_string()),
+        };
+
+        Ok(Github { webhook_data })
+    }
+
+    /// Used to get the branch name from the webhook data related to a push event.
+    pub fn get_branch(&self) -> String {
+        let branch = self.webhook_data.r#ref.clone(); // "refs/heads/issue/123"
+        let branch = &branch["refs/heads/".len()..]; // "issue/123"
+        branch.to_string()
+    }
+
+    /// Used to get the commit id from the webhook data related to a push event.
+    ///
+    /// This is the commit id of the last commit in the push event. Not the same as the branch.
+    pub fn get_commit_id(&self) -> String {
+        self.webhook_data.after.clone()
+    }
+
+    /// Used to get the ssh url of the repository from the webhook data.
+    ///
+    /// This is the url that can be used to clone the repository using ssh.
+    pub fn get_ssh_url(&self) -> String {
+        self.webhook_data.repository.ssh_url.clone()
+    }
+
+    /// Used to get the clone url of the repository from the webhook data.
+    ///
+    /// This is the url that can be used to clone the repository using https.
+    ///
+    /// This can also be used to get the url of the repository on github.
+    pub fn get_clone_url(&self) -> String {
+        self.webhook_data.repository.clone_url.clone()
+    }
+
+    // pub fn send_commit_status(&self, status: &Status) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn real_data() -> String {
+        r#"{"ref": "refs/heads/issue/123", "after": "955c2d172c3b5ac2f125121b8e6c3f99fd560966",
+            "repository": {"ssh_url": "git@github.com:mebn/DD2480.git", "clone_url": "https://github.com/mebn/DD2480.git"}}"#.to_string()
+    }
+
+    fn wrong_data() -> String {
+        r#"{"some key": "some value"}"#.to_string()
+    }
+
+    #[test]
+    fn test_new_fail() {
+        let data = wrong_data();
+        let github = Github::new(&data);
+        assert!(github.is_err());
+    }
+
+    #[test]
+    fn test_get_branch() {
+        let data = real_data();
+        let github = Github::new(&data).unwrap();
+        assert_eq!(github.get_branch(), "issue/123");
+    }
 }


### PR DESCRIPTION
There might be more information from the webhook that we want to keep, but we can do that later.

`Repository` struct is internal/private to this module so it won't interfere `repository.rs`

closes #121 