### PR TITLE
Add: issue #127 paths to LOGS and CI folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# macOS
 .DS_Store
+
+# java
 *.class
+
+# assignment2
 target
-temp
+LOGS
+CI

--- a/assignment2/Cargo.lock
+++ b/assignment2/Cargo.lock
@@ -22,6 +22,7 @@ name = "assignment2"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "lazy_static",
  "serde",
  "serde_json",
  "tokio",
@@ -334,6 +335,12 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/assignment2/Cargo.toml
+++ b/assignment2/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = "0.7.4"
+lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.113"
 tokio = { version = "1.36.0", features = ["full"] }

--- a/assignment2/src/main.rs
+++ b/assignment2/src/main.rs
@@ -10,12 +10,25 @@ pub mod github;
 pub mod repository;
 pub mod routes;
 
+use lazy_static::lazy_static;
 use routes::github_webhook::github_webhook;
 
-// const REPO_PATH: &str = "/tmp/repo";
-// const LOG_PATH: &str = "/tmp/repo";
+// Global variables to paths.
+// Cannot use const because of std::env::current_dir().
+lazy_static! {
+    /// The path to the LOGS directory.
+    /// Used to store the logs from build and test commands.
+    pub static ref LOGS_PATH: std::path::PathBuf = std::env::current_dir()
+        .unwrap().join("LOGS");
+
+    /// The path to the CI directory.
+    /// Used to store the repositories that the server clones.
+    pub static ref CI_PATH: std::path::PathBuf = std::env::current_dir()
+        .unwrap().join("CI");
+}
 
 #[tokio::main]
+/// Starts the CI server and handles all the routes.
 async fn main() {
     let app = Router::new().route("/github_webhook", post(github_webhook));
 


### PR DESCRIPTION
Added paths to`LOGS/` and `CI/` folders that can be used. It uses `current_dir()` so it's important where the server is started. 

For example, if I move `./assignment2` (the executable) to `~/Desktop/`but I execute it at `~/Downloads`, then `LOGS/` and `CI/` would be created at `~/Downloads` and not `~/Desktop/`.

This is not a problem when using `cargo run`, so it dosen't matter for us.

Closes #127 